### PR TITLE
Take the two Kongregate API permanent URL into account

### DIFF
--- a/replace.js
+++ b/replace.js
@@ -58,7 +58,7 @@
     window.fetch = function(req, options) {
         let request = new URL(req instanceof Request ? req.url : req);
 
-        if (request.href.includes("API_AS3_d43c4b859e74432475c1627346078677.swf") || request.href.includes("API_AS3.swf")) {
+        if (request.href.includes("API_AS3_d43c4b859e74432475c1627346078677.swf") || request.href.includes("/flash/API_AS3.swf")) {
             request.href = "https://colin969.github.io/Kongregate-Patched-APIs/API_AS3_MODIFIED.swf";
         }
 

--- a/replace.js
+++ b/replace.js
@@ -58,11 +58,11 @@
     window.fetch = function(req, options) {
         let request = new URL(req instanceof Request ? req.url : req);
 
-        if (request.href.includes("API_AS3_d43c4b859e74432475c1627346078677.swf")) {
+        if (request.href.includes("API_AS3_d43c4b859e74432475c1627346078677.swf") || request.href.includes("API_AS3.swf")) {
             request.href = "https://colin969.github.io/Kongregate-Patched-APIs/API_AS3_MODIFIED.swf";
         }
 
-        if (request.href.includes("API_f99fa1a5a43e48224ae2c0177064456d.swf")) {
+        if (request.href.includes("API_f99fa1a5a43e48224ae2c0177064456d.swf") || request.href.includes("/flash/API.swf")) {
             request.href = "https://colin969.github.io/Kongregate-Patched-APIs/API_AS2_MODIFIED.swf";
         }
 


### PR DESCRIPTION
The URL used on Kongregate pages for both Kongregate API swf changed overtime (whenever they were updated, I guess), so whenever I have to replace them I use the permanent link (which ends with either API.swf or API_AS3.swf). Therefore, I added a check for them.
This should actually be needed for AVM1 games (whenever this becomes relevant), as my user script always use the permanent URL for this API.